### PR TITLE
fix vis_epicontacts with x_axis and thin = FALSE

### DIFF
--- a/R/vis_epicontacts.R
+++ b/R/vis_epicontacts.R
@@ -77,6 +77,7 @@
 #' @return The same output as \code{visNetwork}.
 #'
 #' @seealso \code{\link[visNetwork]{visNetwork}} in the package \code{visNetwork}.
+#'   \code{\link{edges_pal}} and \code{\link{cases_pal}} for color palettes used
 #'
 #' @examples
 #' if (require(outbreaks)) {
@@ -92,6 +93,8 @@
 #' \dontrun{
 #' plot(x)
 #' plot(x, node_color = "place_infect")
+#' # show transmission tree with time as the horizontal axis, showing all nodes
+#' vis_epicontacts(x, x_axis = "dt_onset", thin = FALSE) 
 #' plot(x, node_color = "loc_hosp", legend_max=20, annot=TRUE)
 #' plot(x, node_color = "loc_hosp", legend_max=20, annot=TRUE, x_axis = "dt_onset")
 #' plot(x, "place_infect", node_shape = "sex",
@@ -142,7 +145,6 @@ vis_epicontacts <- function(x, thin = TRUE, node_color = "id", label = "id",
   list_nodes <- x$linelist$id
   ## find out which nodes are unconnected to any other nodes
   ## This is only relevant when `thin = TRUE`
-  orphans <- if (thin) unique(list_nodes[list_nodes %in% cont_nodes]) else NULL
   nodes <- data.frame(id = unique(c(list_nodes, cont_nodes)),
                       stringsAsFactors = FALSE)
 
@@ -211,7 +213,7 @@ vis_epicontacts <- function(x, thin = TRUE, node_color = "id", label = "id",
   ## add edge info
   edges <- x$contacts
   if (!is.null(x_axis)) {
-    if(!inherits(nodes[[x_axis]], c("numeric", "Date", "integer"))) {
+    if (!inherits(nodes[[x_axis]], c("numeric", "Date", "integer"))) {
       stop("Data used to specify x axis must be a date or number")
     }
     drange      <- range(nodes[[x_axis]], na.rm = TRUE)
@@ -245,24 +247,20 @@ vis_epicontacts <- function(x, thin = TRUE, node_color = "id", label = "id",
       dnodes$title <- sprintf("<h3>%s</h3>", dnodes$id)
       nmerge <- c(nmerge, "title")
     }
-    nodes <- merge(nodes, 
-                   dnodes, 
-                   by = nmerge, 
+    nodes <- merge(nodes,
+                   dnodes,
+                   by = nmerge,
                    all = TRUE,
                    sort = FALSE
                   )
     nodes <- nodes[!is.na(nodes$level), , drop = FALSE]
-    nodes$x <- 1
-    if (!is.null(orphans)) {
-	    nodes$x[nodes$id %in% orphans] <- 2
-    }
-    edges <- merge(edges, 
-                   dedges, 
+    edges <- merge(edges,
+                   dedges,
                    by = emerge,
                    all = TRUE,
                    sort = FALSE
                   )
-  }   
+  }
   edges$width <- edge_width
   if (x$directed) {
     edges$arrows <- "to"

--- a/R/vis_epicontacts.R
+++ b/R/vis_epicontacts.R
@@ -138,9 +138,12 @@ vis_epicontacts <- function(x, thin = TRUE, node_color = "id", label = "id",
 
 
   ## make a list of all nodes, and generate a data.frame of node attributes
-  nodes <- data.frame(id = unique(c(x$linelist$id,
-                                    x$contacts$from,
-                                    x$contacts$to)),
+  cont_nodes <- c(x$contacts$from, x$contacts$to)
+  list_nodes <- x$linelist$id
+  ## find out which nodes are unconnected to any other nodes
+  ## This is only relevant when `thin = TRUE`
+  orphans <- if (thin) unique(list_nodes[list_nodes %in% cont_nodes]) else NULL
+  nodes <- data.frame(id = unique(c(list_nodes, cont_nodes)),
                       stringsAsFactors = FALSE)
 
   nodes <- merge(nodes, x$linelist, by = "id", all = TRUE)
@@ -248,14 +251,18 @@ vis_epicontacts <- function(x, thin = TRUE, node_color = "id", label = "id",
                    all = TRUE,
                    sort = FALSE
                   )
+    nodes <- nodes[!is.na(nodes$level), , drop = FALSE]
+    nodes$x <- 1
+    if (!is.null(orphans)) {
+	    nodes$x[nodes$id %in% orphans] <- 2
+    }
     edges <- merge(edges, 
                    dedges, 
                    by = emerge,
                    all = TRUE,
                    sort = FALSE
                   )
-  } 
-  
+  }   
   edges$width <- edge_width
   if (x$directed) {
     edges$arrows <- "to"

--- a/man/vis_epicontacts.Rd
+++ b/man/vis_epicontacts.Rd
@@ -97,6 +97,8 @@ x <- make_epicontacts(linelist=mers_korea_2015[[1]],
 \dontrun{
 plot(x)
 plot(x, node_color = "place_infect")
+# show transmission tree with time as the horizontal axis, showing all nodes
+vis_epicontacts(x, x_axis = "dt_onset", thin = FALSE) 
 plot(x, node_color = "loc_hosp", legend_max=20, annot=TRUE)
 plot(x, node_color = "loc_hosp", legend_max=20, annot=TRUE, x_axis = "dt_onset")
 plot(x, "place_infect", node_shape = "sex",
@@ -109,6 +111,7 @@ plot(x, "sex", node_shape = "sex", shapes = c(F = "female", M = "male"),
 }
 \seealso{
 \code{\link[visNetwork]{visNetwork}} in the package \code{visNetwork}.
+  \code{\link{edges_pal}} and \code{\link{cases_pal}} for color palettes used
 }
 \author{
 Thibaut Jombart (\email{thibautjombart@gmail.com})


### PR DESCRIPTION
The function was not displaying anything if `thin = FALSE` and `x_axis` set to something and there were missing dates. I've added a couple of lines that removes the rows with missing data before its plotted.

the only thing is that vis.js has a "feature" that places the unconnected nodes on a separate position along the free axis, which makes the graph much taller than it is wide if there are a lot of missing connections.