### PR TITLE
Fix 104 2

### DIFF
--- a/R/subset_clusters_by_id.R
+++ b/R/subset_clusters_by_id.R
@@ -48,14 +48,12 @@ subset_clusters_by_id <- function(x, id){
   ## Identify members of cluster belonging to nodes/cases of interest
   id_to_subset <- net_nodes$nodes[ which(net_nodes$cs_member %in% cluster_to_subset)]
 
-  ## Subset linelist and contacts by ids
+  ## Subset linelist and contacts by ids - use 'either' so that all contacts of
+  ## interest are returned, these can be removed using thin if need be later
   epi_subset <- x[i = id_to_subset,
                   j = id_to_subset,
-                  contacts = 'both']
+                  contacts = 'either']
   
   return(epi_subset)
   
 }
-
-
-

--- a/R/subset_clusters_by_id.R
+++ b/R/subset_clusters_by_id.R
@@ -33,31 +33,28 @@
 
 subset_clusters_by_id <- function(x, id){
 
-    # Convert epicontacts object to igraph and get linelist + contacts dataframes
-    net <- as.igraph.epicontacts(x)
-    net_linelist <- igraph::as_data_frame(net, "vertices")
-    net_contacts <- igraph::as_data_frame(net, "edges")
+  ## Convert epicontacts object to igraph and get linelist + contacts dataframes
+  net <- as.igraph.epicontacts(x)
 
-    # Get cluster information for each node/case
-    cs <- igraph::clusters(net)
-    net_nodes <- data.frame(nodes =igraph::V(net)$id,
-                            cs_member = cs$membership,
-                            stringsAsFactors = FALSE)
+  ## Get cluster information for each node/case
+  cs <- igraph::clusters(net)
+  net_nodes <- data.frame(nodes =igraph::V(net)$id,
+                          cs_member = cs$membership,
+                          stringsAsFactors = FALSE)
 
-    # Identify cluster containing nodes/cases of interest
-    cluster_to_subset <- unique(net_nodes$cs_member[which(net_nodes$nodes %in% id)])
+  ## Identify cluster containing nodes/cases of interest
+  cluster_to_subset <- unique(net_nodes$cs_member[which(net_nodes$nodes %in% id)])
 
-    # Identify members of cluster belonging to nodes/cases of interest
-    id_to_subset <- net_nodes$nodes[ which(net_nodes$cs_member %in% cluster_to_subset)]
-    # Create new epicontacts object with cluster members
-    new_linelist <- net_linelist[ net_linelist$name %in% id_to_subset, ]
-    new_contacts <- net_contacts[ net_contacts$from %in% id_to_subset |
-                                  net_contacts$to %in% id_to_subset, ]
+  ## Identify members of cluster belonging to nodes/cases of interest
+  id_to_subset <- net_nodes$nodes[ which(net_nodes$cs_member %in% cluster_to_subset)]
 
-    # Return new epicontacts object
-    epi_subset <- make_epicontacts(new_linelist, new_contacts, directed = x$directed)
-    
-    return(epi_subset)
+  ## Subset linelist and contacts by ids
+  epi_subset <- x[i = id_to_subset,
+                  j = id_to_subset,
+                  contacts = 'both']
+  
+  return(epi_subset)
+  
 }
 
 


### PR DESCRIPTION
- no longer going from epicontacts -> igraph -> epicontacts which was causing a bunch of issues
- using the native square bracket subsetting instead and keeping all linelist and contact elements associated with a given cluster
- using 'either' not 'both' so that all contact elements of interested are returned, even if one of them is not in the linelist
- added functional tests to ensure the correct clusters are being returned