### PR TITLE
Coping with non-clustered cases in contacts dataframe

### DIFF
--- a/R/get_clusters.R
+++ b/R/get_clusters.R
@@ -80,7 +80,7 @@ get_clusters <- function(x, output = c("epicontacts", "data.frame"),
 
 
   if(!no_infector){
-    x_full <- x
+    x_full <- x$linelist
     x$contacts <- x$contacts[which(!is.na(x$contacts$from)),]
     x$linelist <- x$linelist[which(x$linelist$id %in% c(x$contacts$from, x$contacts$to)),]
   }
@@ -107,7 +107,7 @@ get_clusters <- function(x, output = c("epicontacts", "data.frame"),
   net_nodes <- dplyr::left_join(net_nodes, cs_size, by = member_col)
   if(output == "epicontacts") {
     if(!no_infector){
-      x$linelist <- dplyr::full_join(x_full$linelist, net_nodes, by = "id")
+      x$linelist <- dplyr::full_join(x_full, net_nodes, by = "id")
     } else {
       x$linelist <- dplyr::full_join(x$linelist, net_nodes, by = "id")
     }

--- a/R/get_clusters.R
+++ b/R/get_clusters.R
@@ -24,6 +24,9 @@
 #' @param override Logical value indicating whether cluster member and size columns
 #' should be overwritten if they already exist in the linelist. Default is 'FALSE'.
 #'
+#'  @param no_infector Logical value indicating whether to assign clusters to cases with no
+#' infector in the contacts dataframe. Default is 'TRUE'.
+#'
 #' @return An \code{\link{epicontacts}} object whose 'linelist' dataframe
 #' contains new columns corresponding to cluster membership and size, or a
 #' \link{data.frame} containing member ids, cluster memberships as factors,
@@ -57,7 +60,8 @@
 get_clusters <- function(x, output = c("epicontacts", "data.frame"),
                          member_col = "cluster_member",
                          size_col = "cluster_size",
-                         override = FALSE) {
+                         override = FALSE,
+                         no_infector = TRUE) {
 
   ## check if cluster columns pre-exist in linelist
   cluster_cols <- c(member_col, size_col)
@@ -75,6 +79,13 @@ get_clusters <- function(x, output = c("epicontacts", "data.frame"),
   }
 
 
+  if(!no_infector){
+    x_full <- x
+    x$contacts <- x$contacts[which(!is.na(x$contacts$from)),]
+    x$linelist <- x$linelist[which(x$linelist$id %in% c(x$contacts$from, x$contacts$to)),]
+  }
+  
+  
   output <- match.arg(output)
   net <- as.igraph.epicontacts(x)
   cs <- igraph::clusters(net)
@@ -95,7 +106,11 @@ get_clusters <- function(x, output = c("epicontacts", "data.frame"),
 
   net_nodes <- dplyr::left_join(net_nodes, cs_size, by = member_col)
   if(output == "epicontacts") {
-    x$linelist <- dplyr::full_join(x$linelist, net_nodes, by = "id")
+    if(!no_infector){
+      x$linelist <- dplyr::full_join(x_full$linelist, net_nodes, by = "id")
+    } else {
+      x$linelist <- dplyr::full_join(x$linelist, net_nodes, by = "id")
+    }
     x$linelist[ member_col ] <- as.factor(x$linelist[[ member_col ]])
     return(x)
   } else {

--- a/man/get_clusters.Rd
+++ b/man/get_clusters.Rd
@@ -4,9 +4,14 @@
 \alias{get_clusters}
 \title{Assign cluster IDs to epicontacts data}
 \usage{
-get_clusters(x, output = c("epicontacts", "data.frame"),
-  member_col = "cluster_member", size_col = "cluster_size",
-  override = FALSE)
+get_clusters(
+  x,
+  output = c("epicontacts", "data.frame"),
+  member_col = "cluster_member",
+  size_col = "cluster_size",
+  override = FALSE,
+  no_infector = TRUE
+)
 }
 \arguments{
 \item{x}{An \code{\link{epicontacts}} object.}
@@ -24,6 +29,9 @@ linelist. Default name is 'cluster_size'.}
 
 \item{override}{Logical value indicating whether cluster member and size columns
 should be overwritten if they already exist in the linelist. Default is 'FALSE'.}
+
+\item{no_infector}{Logical value indicating whether to assign clusters to cases with no
+infector in the contacts dataframe. Default is 'TRUE'.}
 }
 \value{
 An \code{\link{epicontacts}} object whose 'linelist' dataframe
@@ -44,7 +52,8 @@ x <- make_epicontacts(ebola_sim$linelist, ebola_sim$contacts,
                        id = "case_id",
                        to = "case_id",
                        from = "infector",
-                       directed = TRUE)
+                       directed = TRUE,
+                       no_infector = TRUE)
 
 
 ## add cluster membership and sizes to epicontacts 'linelist'


### PR DESCRIPTION
Because cases in the linelist who do not appear in the contacts dataframe with from as NA do not have their node attributes displayed, just their ID, it is necessary to include them in the contacts. However, {igraph} in the get_clusters function turns NA to 'NA' and so falsely considers non-connected cases as one cluster. 

Although this does not change default behaviour it does allow for users to have a linelist returned which does not assign clusters to non-clustered cases.

The minor fix was required due to an issue in copying an epicontacts object but has now been tested and works as expected