### PR TITLE
Remove deprecation warning from `print.epicontacts()`

### DIFF
--- a/R/print.epicontacts.R
+++ b/R/print.epicontacts.R
@@ -21,10 +21,10 @@ print.epicontacts <- function(x, ...){
         "\n")
 
     cat("\n  // linelist\n\n")
-    print(dplyr::tbl_df(x$linelist))
+    print(dplyr::as_tibble(x$linelist))
 
     cat("\n  // contacts\n\n")
-    print(dplyr::tbl_df(x$contacts))
+    print(dplyr::as_tibble(x$contacts))
 
     cat("\n")
 }


### PR DESCRIPTION
This PR replaces the call to `dplyr::tbl_df()` with `dplyr::as_tibble()` in `print.epicontacts()` to close #131. 